### PR TITLE
Add `user_can_download` to dataset resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 build/
 dist/
 .cache/
+__pycache__
 python_databasin.egg-info/
 .pytest_cache/

--- a/databasin/datasets.py
+++ b/databasin/datasets.py
@@ -25,6 +25,7 @@ class DatasetResource(Resource):
     contact_persons = fields.TextField(required=False)
     is_aggregate = fields.BooleanField(default=False)
     can_download = fields.BooleanField(default=False)
+    user_can_download = fields.BooleanField(default=False)
     allow_anonymous_download = fields.BooleanField(default=False)
     can_comment = fields.BooleanField(default=False)
     tags = fields.ObjectField()


### PR DESCRIPTION
Resolves #5 - adds a `user_can_download` property to the dataset resource that can be used to determine user-specific download privileges for the dataset.  `can_download` is based on the global download setting for the dataset.

Also adds additional ignore directory.